### PR TITLE
Develop

### DIFF
--- a/addons/sourcemod/configs/war3source_help_menu.cfg
+++ b/addons/sourcemod/configs/war3source_help_menu.cfg
@@ -22,418 +22,424 @@
 // but you can have 1 question and all 4 commands if you want.
 // empty commands or non-existant commands do nothing.
 //
-"CSGO"
+"war3sourcehelpmenu"
 {
-	"0"
-	{
-		"question"				"What are my skills and their levels? - \"!myinfo\""
-		"fakeclientcommand"		"say !myinfo"
-		"chatmessage"			""
-		"consolemessage"		""
-		"servercommand"			""
-	}
-	"0"
-	{
-		"question" "What are all the races? - \"!raceinfo\""
-		"fakeclientcommand"   "say !raceinfo"
-	}
-	"0"
-	{
-		"question" "Change my race - \"!changerace\""
-		"fakeclientcommand"   "say !changerace"
-	}
-	"0"
-	{
-		"question" "What races are people playing? - \"!playerinfo\" "
-		"fakeclientcommand"   "say !playerinfo"
-	}
-	"0"
-	{
-		"question" "Buy items with gold that last until death - \"!sh1\""
-		"fakeclientcommand"   "say !sh1"
-	}
-	"0"
-	{
-		"question" "Buy items with diamonds that last until map change - \"!sh2\""
-		"fakeclientcommand"   "say !sh2"
-	}
-	"0"
-	{
-		"question" "Buy items with platinum that last forever - \"!sh3\""
-		"fakeclientcommand"   "say !sh3"
-	}
-	"0"
-	{
-		"question" "How do I bind a key? - \"!bind\""
-		"fakeclientcommand"   "say !bind"
-	}
-	"0"
-	{
-		"question" "Reset my current race's skills - \"!resetskills\""
-		"fakeclientcommand"   "say !resetskills"
-	}
-	"0"
-	{
-		"question" "Spend my unused skill points - \"!spendskills\""
-		"fakeclientcommand"   "say !spendskills"
-	}
-	"0"
-	{
-		"question" "Spend my levelbanks - \"!levelbank\""
-		"fakeclientcommand"   "say !levelbank"
-	}
-	"0"
-	{
-		"question" "Open the forums - \"!forums\""
-		"fakeclientcommand"   "say !forums"
-	}
-	"0"
-	{
-		"question" "Open the donor page - \"!donate\""
-		"fakeclientcommand"   "say !donate"
-	}
-	"0"
-	{
-		"question" "How do I tag up for bonus xp/gold? - \"!taghelp\""
-		"fakeclientcommand"   "say !taghelp"
-	}
-	"0"
-	{
-		"question" "How do I view the players with the most levels? - \"!war3top10\""
-		"fakeclientcommand"   "say !war3top10"
-	}
-	"0"
-	{
-		"question" "Open the full commands listing - \"!commands\""
-		"fakeclientcommand"   "say !commands"
-	}
-	"0"
-	{
-		"question" "View recent mod updates - \"!update\""
-		"fakeclientcommand"   "say !update"
-	}
-	"0"
-	{
-		"question" "Shopmenu (sh1) information  - \"!itemsinfo\""
-		"fakeclientcommand"   "say !itemsinfo"
-	}
-	"0"
-	{
-		"question" "Shopmenu2 (sh2) information  - \"!itemsinfo2\""
-		"fakeclientcommand"   "say !itemsinfo2"
-	}
-	"0"
-	{
-		"question" "Shopmenu3 (sh3) information  - \"!itemsinfo3\""
-		"fakeclientcommand"   "say !itemsinfo3"
-	}
-}
-"CSS"
-{
-	"0"
-	{
-		"question" "What are my skills and their levels? - \"!myinfo\""
-		"fakeclientcommand"   "say !myinfo"
-	}
-	"0"
-	{
-		"question" "What are all the races? - \"!raceinfo\""
-		"fakeclientcommand"   "say !raceinfo"
-	}
-	"0"
-	{
-		"question" "Change my race - \"!changerace\""
-		"fakeclientcommand"   "say !changerace"
-	}
-	"0"
-	{
-		"question" "What races are people playing? - \"!playerinfo\" "
-		"fakeclientcommand"   "say !playerinfo"
-	}
-	"0"
-	{
-		"question" "Buy items with gold that last until death - \"!sh1\""
-		"fakeclientcommand"   "say !sh1"
-	}
-	"0"
-	{
-		"question" "Buy items with diamonds that last until map change - \"!sh2\""
-		"fakeclientcommand"   "say !sh2"
-	}
-	"0"
-	{
-		"question" "Buy items with platinum that last forever - \"!sh3\""
-		"fakeclientcommand"   "say !sh3"
-	}
-	"0"
-	{
-		"question" "How do I bind a key? - \"!bind\""
-		"fakeclientcommand"   "say !bind"
-	}
-	"0"
-	{
-		"question" "Reset my current race's skills - \"!resetskills\""
-		"fakeclientcommand"   "say !resetskills"
-	}
-	"0"
-	{
-		"question" "Spend my unused skill points - \"!spendskills\""
-		"fakeclientcommand"   "say !spendskills"
-	}
-	"0"
-	{
-		"question" "Spend my levelbanks - \"!levelbank\""
-		"fakeclientcommand"   "say !levelbank"
-	}
-	"0"
-	{
-		"question" "Open the forums - \"!forums\""
-		"fakeclientcommand"   "say !forums"
-	}
-	"0"
-	{
-		"question" "Open the donor page - \"!donate\""
-		"fakeclientcommand"   "say !donate"
-	}
-	"0"
-	{
-		"question" "How do I tag up for bonus xp/gold? - \"!taghelp\""
-		"fakeclientcommand"   "say !taghelp"
-	}
-	"0"
-	{
-		"question" "How do I view the players with the most levels? - \"!war3top10\""
-		"fakeclientcommand"   "say !war3top10"
-	}
-	"0"
-	{
-		"question" "Open the full commands listing - \"!commands\""
-		"fakeclientcommand"   "say !commands"
-	}
-	"0"
-	{
-		"question" "View recent mod updates - \"!update\""
-		"fakeclientcommand"   "say !update"
-	}
-	"0"
-	{
-		"question" "Shopmenu (sh1) information  - \"!itemsinfo\""
-		"fakeclientcommand"   "say !itemsinfo"
-	}
-	"0"
-	{
-		"question" "Shopmenu2 (sh2) information  - \"!itemsinfo2\""
-		"fakeclientcommand"   "say !itemsinfo2"
-	}
-	"0"
-	{
-		"question" "Shopmenu3 (sh3) information  - \"!itemsinfo3\""
-		"fakeclientcommand"   "say !itemsinfo3"
-	}
-}
-"TF2"
-{
-	"0"
-	{
-		"question" "What are my skills and their levels? - \"!myinfo\""
-		"fakeclientcommand"   "say !myinfo"
-	}
-	"0"
-	{
-		"question" "What are all the races? - \"!raceinfo\""
-		"fakeclientcommand"   "say !raceinfo"
-	}
-	"0"
-	{
-		"question" "Change my race - \"!changerace\""
-		"fakeclientcommand"   "say !changerace"
-	}
-	"0"
-	{
-		"question" "What races are people playing? - \"!playerinfo\" "
-		"fakeclientcommand"   "say !playerinfo"
-	}
-	"0"
-	{
-		"question" "Buy items with gold that last until death - \"!sh1\""
-		"fakeclientcommand"   "say !sh1"
-	}
-	"0"
-	{
-		"question" "Buy items with diamonds that last until map change - \"!sh2\""
-		"fakeclientcommand"   "say !sh2"
-	}
-	"0"
-	{
-		"question" "Buy items with platinum that last forever - \"!sh3\""
-		"fakeclientcommand"   "say !sh3"
-	}
-	"0"
-	{
-		"question" "How do I bind a key? - \"!bind\""
-		"fakeclientcommand"   "say !bind"
-	}
-	"0"
-	{
-		"question" "Reset my current race's skills - \"!resetskills\""
-		"fakeclientcommand"   "say !resetskills"
-	}
-	"0"
-	{
-		"question" "Spend my unused skill points - \"!spendskills\""
-		"fakeclientcommand"   "say !spendskills"
-	}
-	"0"
-	{
-		"question" "Spend my levelbanks - \"!levelbank\""
-		"fakeclientcommand"   "say !levelbank"
-	}
-	"0"
-	{
-		"question" "Open the forums - \"!forums\""
-		"fakeclientcommand"   "say !forums"
-	}
-	"0"
-	{
-		"question" "Open the donor page - \"!donate\""
-		"fakeclientcommand"   "say !donate"
-	}
-	"0"
-	{
-		"question" "How do I tag up for bonus xp/gold? - \"!taghelp\""
-		"fakeclientcommand"   "say !taghelp"
-	}
-	"0"
-	{
-		"question" "How do I view the players with the most levels? - \"!war3top10\""
-		"fakeclientcommand"   "say !war3top10"
-	}
-	"0"
-	{
-		"question" "Open the full commands listing - \"!commands\""
-		"fakeclientcommand"   "say !commands"
-	}
-	"0"
-	{
-		"question" "View recent mod updates - \"!update\""
-		"fakeclientcommand"   "say !update"
-	}
-	"0"
-	{
-		"question" "Shopmenu (sh1) information  - \"!itemsinfo\""
-		"fakeclientcommand"   "say !itemsinfo"
-	}
-	"0"
-	{
-		"question" "Shopmenu2 (sh2) information  - \"!itemsinfo2\""
-		"fakeclientcommand"   "say !itemsinfo2"
-	}
-	"0"
-	{
-		"question" "Shopmenu3 (sh3) information  - \"!itemsinfo3\""
-		"fakeclientcommand"   "say !itemsinfo3"
-	}
-}
-"FOF"
-{
-	"0"
-	{
-		"question" "What are my skills and their levels? - \"!myinfo\""
-		"fakeclientcommand"   "say !myinfo"
-	}
-	"0"
-	{
-		"question" "What are all the races? - \"!raceinfo\""
-		"fakeclientcommand"   "say !raceinfo"
-	}
-	"0"
-	{
-		"question" "Change my race - \"!changerace\""
-		"fakeclientcommand"   "say !changerace"
-	}
-	"0"
-	{
-		"question" "What races are people playing? - \"!playerinfo\" "
-		"fakeclientcommand"   "say !playerinfo"
-	}
-	"0"
-	{
-		"question" "Buy items with gold that last until death - \"!sh1\""
-		"fakeclientcommand"   "say !sh1"
-	}
-	"0"
-	{
-		"question" "Buy items with diamonds that last until map change - \"!sh2\""
-		"fakeclientcommand"   "say !sh2"
-	}
-	"0"
-	{
-		"question" "Buy items with platinum that last forever - \"!sh3\""
-		"fakeclientcommand"   "say !sh3"
-	}
-	"0"
-	{
-		"question" "How do I bind a key? - \"!bind\""
-		"fakeclientcommand"   "say !bind"
-	}
-	"0"
-	{
-		"question" "Reset my current race's skills - \"!resetskills\""
-		"fakeclientcommand"   "say !resetskills"
-	}
-	"0"
-	{
-		"question" "Spend my unused skill points - \"!spendskills\""
-		"fakeclientcommand"   "say !spendskills"
-	}
-	"0"
-	{
-		"question" "Spend my levelbanks - \"!levelbank\""
-		"fakeclientcommand"   "say !levelbank"
-	}
-	"0"
-	{
-		"question" "Open the forums - \"!forums\""
-		"fakeclientcommand"   "say !forums"
-	}
-	"0"
-	{
-		"question" "Open the donor page - \"!donate\""
-		"fakeclientcommand"   "say !donate"
-	}
-	"0"
-	{
-		"question" "How do I tag up for bonus xp/gold? - \"!taghelp\""
-		"fakeclientcommand"   "say !taghelp"
-	}
-	"0"
-	{
-		"question" "How do I view the players with the most levels? - \"!war3top10\""
-		"fakeclientcommand"   "say !war3top10"
-	}
-	"0"
-	{
-		"question" "Open the full commands listing - \"!commands\""
-		"fakeclientcommand"   "say !commands"
-	}
-	"0"
-	{
-		"question" "View recent mod updates - \"!update\""
-		"fakeclientcommand"   "say !update"
-	}
-	"0"
-	{
-		"question" "Shopmenu (sh1) information  - \"!itemsinfo\""
-		"fakeclientcommand"   "say !itemsinfo"
-	}
-	"0"
-	{
-		"question" "Shopmenu2 (sh2) information  - \"!itemsinfo2\""
-		"fakeclientcommand"   "say !itemsinfo2"
-	}
-	"0"
-	{
-		"question" "Shopmenu3 (sh3) information  - \"!itemsinfo3\""
-		"fakeclientcommand"   "say !itemsinfo3"
+	"CSGO"
+	{
+		"0"
+		{
+			"question"				"What are my skills and their levels? - \"!myinfo\""
+			"fakeclientcommand"		"say !myinfo"
+			"chatmessage"			""
+			"consolemessage"		""
+			"servercommand"			""
+		}
+		"0"
+		{
+			"question" "What are all the races? - \"!raceinfo\""
+			"fakeclientcommand"   "say !raceinfo"
+		}
+		"0"
+		{
+			"question" "Change my race - \"!changerace\""
+			"fakeclientcommand"   "say !changerace"
+		}
+		"0"
+		{
+			"question" "What races are people playing? - \"!playerinfo\" "
+			"fakeclientcommand"   "say !playerinfo"
+		}
+		"0"
+		{
+			"question" "Buy items with gold that last until death - \"!sh1\""
+			"fakeclientcommand"   "say !sh1"
+		}
+		"0"
+		{
+			"question" "Buy items with diamonds that last until map change - \"!sh2\""
+			"fakeclientcommand"   "say !sh2"
+		}
+		"0"
+		{
+			"question" "Buy items with platinum that last forever - \"!sh3\""
+			"fakeclientcommand"   "say !sh3"
+		}
+		"0"
+		{
+			"question" "How do I bind a key? - \"!bind\""
+			"fakeclientcommand"   "say !bind"
+		}
+		"0"
+		{
+			"question" "Reset my current race's skills - \"!resetskills\""
+			"fakeclientcommand"   "say !resetskills"
+		}
+		"0"
+		{
+			"question" "Spend my unused skill points - \"!spendskills\""
+			"fakeclientcommand"   "say !spendskills"
+		}
+		"0"
+		{
+			"question" "Spend my levelbanks - \"!levelbank\""
+			"fakeclientcommand"   "say !levelbank"
+		}
+		"0"
+		{
+			"question" "Open the forums - \"!forums\""
+			"fakeclientcommand"   "say !forums"
+		}
+		"0"
+		{
+			"question" "Open the donor page - \"!donate\""
+			"fakeclientcommand"   "say !donate"
+		}
+		"0"
+		{
+			"question" "How do I tag up for bonus xp/gold? - \"!taghelp\""
+			"fakeclientcommand"   "say !taghelp"
+		}
+		"0"
+		{
+			"question" "How do I view the players with the most levels? - \"!war3top10\""
+			"fakeclientcommand"   "say !war3top10"
+		}
+		"0"
+		{
+			"question" "Open the full commands listing - \"!commands\""
+			"fakeclientcommand"   "say !commands"
+		}
+		"0"
+		{
+			"question" "View recent mod updates - \"!update\""
+			"fakeclientcommand"   "say !update"
+		}
+		"0"
+		{
+			"question" "Shopmenu (sh1) information  - \"!itemsinfo\""
+			"fakeclientcommand"   "say !itemsinfo"
+		}
+		"0"
+		{
+			"question" "Shopmenu2 (sh2) information  - \"!itemsinfo2\""
+			"fakeclientcommand"   "say !itemsinfo2"
+		}
+		"0"
+		{
+			"question" "Shopmenu3 (sh3) information  - \"!itemsinfo3\""
+			"fakeclientcommand"   "say !itemsinfo3"
+		}
+	}
+	"CSS"
+	{
+		"0"
+		{
+			"question" "What are my skills and their levels? - \"!myinfo\""
+			"fakeclientcommand"   "say !myinfo"
+			"chatmessage"			""
+			"consolemessage"		""
+			"servercommand"			""
+		}
+		"0"
+		{
+			"question" "What are all the races? - \"!raceinfo\""
+			"fakeclientcommand"   "say !raceinfo"
+		}
+		"0"
+		{
+			"question" "Change my race - \"!changerace\""
+			"fakeclientcommand"   "say !changerace"
+		}
+		"0"
+		{
+			"question" "What races are people playing? - \"!playerinfo\" "
+			"fakeclientcommand"   "say !playerinfo"
+		}
+		"0"
+		{
+			"question" "Buy items with gold that last until death - \"!sh1\""
+			"fakeclientcommand"   "say !sh1"
+		}
+		"0"
+		{
+			"question" "Buy items with diamonds that last until map change - \"!sh2\""
+			"fakeclientcommand"   "say !sh2"
+		}
+		"0"
+		{
+			"question" "Buy items with platinum that last forever - \"!sh3\""
+			"fakeclientcommand"   "say !sh3"
+		}
+		"0"
+		{
+			"question" "How do I bind a key? - \"!bind\""
+			"fakeclientcommand"   "say !bind"
+		}
+		"0"
+		{
+			"question" "Reset my current race's skills - \"!resetskills\""
+			"fakeclientcommand"   "say !resetskills"
+		}
+		"0"
+		{
+			"question" "Spend my unused skill points - \"!spendskills\""
+			"fakeclientcommand"   "say !spendskills"
+		}
+		"0"
+		{
+			"question" "Spend my levelbanks - \"!levelbank\""
+			"fakeclientcommand"   "say !levelbank"
+		}
+		"0"
+		{
+			"question" "Open the forums - \"!forums\""
+			"fakeclientcommand"   "say !forums"
+		}
+		"0"
+		{
+			"question" "Open the donor page - \"!donate\""
+			"fakeclientcommand"   "say !donate"
+		}
+		"0"
+		{
+			"question" "How do I tag up for bonus xp/gold? - \"!taghelp\""
+			"fakeclientcommand"   "say !taghelp"
+		}
+		"0"
+		{
+			"question" "How do I view the players with the most levels? - \"!war3top10\""
+			"fakeclientcommand"   "say !war3top10"
+		}
+		"0"
+		{
+			"question" "Open the full commands listing - \"!commands\""
+			"fakeclientcommand"   "say !commands"
+		}
+		"0"
+		{
+			"question" "View recent mod updates - \"!update\""
+			"fakeclientcommand"   "say !update"
+		}
+		"0"
+		{
+			"question" "Shopmenu (sh1) information  - \"!itemsinfo\""
+			"fakeclientcommand"   "say !itemsinfo"
+		}
+		"0"
+		{
+			"question" "Shopmenu2 (sh2) information  - \"!itemsinfo2\""
+			"fakeclientcommand"   "say !itemsinfo2"
+		}
+		"0"
+		{
+			"question" "Shopmenu3 (sh3) information  - \"!itemsinfo3\""
+			"fakeclientcommand"   "say !itemsinfo3"
+		}
+	}
+	"TF2"
+	{
+		"0"
+		{
+			"question" "What are my skills and their levels? - \"!myinfo\""
+			"fakeclientcommand"   "say !myinfo"
+		}
+		"0"
+		{
+			"question" "What are all the races? - \"!raceinfo\""
+			"fakeclientcommand"   "say !raceinfo"
+		}
+		"0"
+		{
+			"question" "Change my race - \"!changerace\""
+			"fakeclientcommand"   "say !changerace"
+		}
+		"0"
+		{
+			"question" "What races are people playing? - \"!playerinfo\" "
+			"fakeclientcommand"   "say !playerinfo"
+		}
+		"0"
+		{
+			"question" "Buy items with gold that last until death - \"!sh1\""
+			"fakeclientcommand"   "say !sh1"
+		}
+		"0"
+		{
+			"question" "Buy items with diamonds that last until map change - \"!sh2\""
+			"fakeclientcommand"   "say !sh2"
+		}
+		"0"
+		{
+			"question" "Buy items with platinum that last forever - \"!sh3\""
+			"fakeclientcommand"   "say !sh3"
+		}
+		"0"
+		{
+			"question" "How do I bind a key? - \"!bind\""
+			"fakeclientcommand"   "say !bind"
+		}
+		"0"
+		{
+			"question" "Reset my current race's skills - \"!resetskills\""
+			"fakeclientcommand"   "say !resetskills"
+		}
+		"0"
+		{
+			"question" "Spend my unused skill points - \"!spendskills\""
+			"fakeclientcommand"   "say !spendskills"
+		}
+		"0"
+		{
+			"question" "Spend my levelbanks - \"!levelbank\""
+			"fakeclientcommand"   "say !levelbank"
+		}
+		"0"
+		{
+			"question" "Open the forums - \"!forums\""
+			"fakeclientcommand"   "say !forums"
+		}
+		"0"
+		{
+			"question" "Open the donor page - \"!donate\""
+			"fakeclientcommand"   "say !donate"
+		}
+		"0"
+		{
+			"question" "How do I tag up for bonus xp/gold? - \"!taghelp\""
+			"fakeclientcommand"   "say !taghelp"
+		}
+		"0"
+		{
+			"question" "How do I view the players with the most levels? - \"!war3top10\""
+			"fakeclientcommand"   "say !war3top10"
+		}
+		"0"
+		{
+			"question" "Open the full commands listing - \"!commands\""
+			"fakeclientcommand"   "say !commands"
+		}
+		"0"
+		{
+			"question" "View recent mod updates - \"!update\""
+			"fakeclientcommand"   "say !update"
+		}
+		"0"
+		{
+			"question" "Shopmenu (sh1) information  - \"!itemsinfo\""
+			"fakeclientcommand"   "say !itemsinfo"
+		}
+		"0"
+		{
+			"question" "Shopmenu2 (sh2) information  - \"!itemsinfo2\""
+			"fakeclientcommand"   "say !itemsinfo2"
+		}
+		"0"
+		{
+			"question" "Shopmenu3 (sh3) information  - \"!itemsinfo3\""
+			"fakeclientcommand"   "say !itemsinfo3"
+		}
+	}
+	"FOF"
+	{
+		"0"
+		{
+			"question" "What are my skills and their levels? - \"!myinfo\""
+			"fakeclientcommand"   "say !myinfo"
+		}
+		"0"
+		{
+			"question" "What are all the races? - \"!raceinfo\""
+			"fakeclientcommand"   "say !raceinfo"
+		}
+		"0"
+		{
+			"question" "Change my race - \"!changerace\""
+			"fakeclientcommand"   "say !changerace"
+		}
+		"0"
+		{
+			"question" "What races are people playing? - \"!playerinfo\" "
+			"fakeclientcommand"   "say !playerinfo"
+		}
+		"0"
+		{
+			"question" "Buy items with gold that last until death - \"!sh1\""
+			"fakeclientcommand"   "say !sh1"
+		}
+		"0"
+		{
+			"question" "Buy items with diamonds that last until map change - \"!sh2\""
+			"fakeclientcommand"   "say !sh2"
+		}
+		"0"
+		{
+			"question" "Buy items with platinum that last forever - \"!sh3\""
+			"fakeclientcommand"   "say !sh3"
+		}
+		"0"
+		{
+			"question" "How do I bind a key? - \"!bind\""
+			"fakeclientcommand"   "say !bind"
+		}
+		"0"
+		{
+			"question" "Reset my current race's skills - \"!resetskills\""
+			"fakeclientcommand"   "say !resetskills"
+		}
+		"0"
+		{
+			"question" "Spend my unused skill points - \"!spendskills\""
+			"fakeclientcommand"   "say !spendskills"
+		}
+		"0"
+		{
+			"question" "Spend my levelbanks - \"!levelbank\""
+			"fakeclientcommand"   "say !levelbank"
+		}
+		"0"
+		{
+			"question" "Open the forums - \"!forums\""
+			"fakeclientcommand"   "say !forums"
+		}
+		"0"
+		{
+			"question" "Open the donor page - \"!donate\""
+			"fakeclientcommand"   "say !donate"
+		}
+		"0"
+		{
+			"question" "How do I tag up for bonus xp/gold? - \"!taghelp\""
+			"fakeclientcommand"   "say !taghelp"
+		}
+		"0"
+		{
+			"question" "How do I view the players with the most levels? - \"!war3top10\""
+			"fakeclientcommand"   "say !war3top10"
+		}
+		"0"
+		{
+			"question" "Open the full commands listing - \"!commands\""
+			"fakeclientcommand"   "say !commands"
+		}
+		"0"
+		{
+			"question" "View recent mod updates - \"!update\""
+			"fakeclientcommand"   "say !update"
+		}
+		"0"
+		{
+			"question" "Shopmenu (sh1) information  - \"!itemsinfo\""
+			"fakeclientcommand"   "say !itemsinfo"
+		}
+		"0"
+		{
+			"question" "Shopmenu2 (sh2) information  - \"!itemsinfo2\""
+			"fakeclientcommand"   "say !itemsinfo2"
+		}
+		"0"
+		{
+			"question" "Shopmenu3 (sh3) information  - \"!itemsinfo3\""
+			"fakeclientcommand"   "say !itemsinfo3"
+		}
 	}
 }

--- a/addons/sourcemod/scripting/War3Source/War3Source_Engine_SteamTools.sp
+++ b/addons/sourcemod/scripting/War3Source/War3Source_Engine_SteamTools.sp
@@ -75,7 +75,10 @@ public Action:Command_Refresh(args)
 	{
 		if(ValidPlayer(client,false) && !IsFakeClient(client))
 		{
-			Steam_RequestGroupStatus(client, GetConVarInt(g_hClanID));
+			if(LibraryExists("SteamTools"))
+			{
+				Steam_RequestGroupStatus(client, GetConVarInt(g_hClanID));
+			}
 		}
 	}
 	PrintToServer("[W3E] Repolling groupstatus...");
@@ -110,7 +113,10 @@ public War3Source_Engine_SteamTools_OnClientPutInServer(client)
 		if(check_steamtools()) {
 			new iGroupID = GetConVarInt(g_hClanID);
 			if(iGroupID != 0) {
-				Steam_RequestGroupStatus(client, iGroupID);
+				if(LibraryExists("SteamTools"))
+				{
+					Steam_RequestGroupStatus(client, iGroupID);
+				}
 			}
 		}
 	}
@@ -122,7 +128,10 @@ public Action:WelcomeAdvertTimer (Handle:timer, any:client)
 	{
 		if(ValidPlayer(x,false) && !IsFakeClient(x))
 		{
-			Steam_RequestGroupStatus(x, GetConVarInt(g_hClanID));
+			if(LibraryExists("SteamTools"))
+			{
+				Steam_RequestGroupStatus(x, GetConVarInt(g_hClanID));
+			}
 		}
 	}
 	//PrintToServer("[W3E] Repolling groupstatus...");

--- a/addons/sourcemod/scripting/War3Source_Addon_AdminConsole.sp
+++ b/addons/sourcemod/scripting/War3Source_Addon_AdminConsole.sp
@@ -107,18 +107,15 @@ public Action War3Source_CMDRemovePlayer(int client,int args)
 		int x=0;
 		while(x<results)
 		{
+			x+=1;
 			if(!ValidPlayer(x)) continue;
 
-			new steamaccountid = GetSteamAccountID(client);
+			new steamaccountid = GetSteamAccountID(x);
 
 			char name[64];
 			GetClientName(playerlist[x],name,sizeof(name));
 
-			War3_ChatMessage(client,"Your being deleted from database.");
-
-			KickClient(client, "%t", "Kicked by admin");
-			results-=1;
-			x+=1;
+			War3_ChatMessage(x,"Your being deleted from database.");
 
 			// Remove player from database
 			hDB = W3GetVar(hDatabase);
@@ -133,7 +130,7 @@ public Action War3Source_CMDRemovePlayer(int client,int args)
 				Format(longquery,sizeof(longquery),"DELETE FROM %s WHERE steamid='%d';",XP_GOLD_DATABASENAME,steamaccountid);
 
 				StringMap QueryCode = new StringMap();
-				QueryCode.SetValue("client",client);
+				QueryCode.SetValue("client",x);
 				QueryCode.SetString("query",longquery);
 
 				SQL_TQuery(hDB,T_CallbackDeletePlayer,longquery,QueryCode,DBPrio_High);
@@ -145,7 +142,7 @@ public Action War3Source_CMDRemovePlayer(int client,int args)
 				Format(longquery,sizeof(longquery),"DELETE FROM %s WHERE steamid='%d';",XP_GOLD_DATABASENAME_RACEDATA1,steamaccountid);
 
 				StringMap QueryCode2 = new StringMap();
-				QueryCode2.SetValue("client",client);
+				QueryCode2.SetValue("client",x);
 				QueryCode2.SetString("query",longquery);
 
 				SQL_TQuery(hDB,T_CallbackDeletePlayer,longquery,QueryCode2,DBPrio_High);
@@ -169,8 +166,22 @@ public Action War3Source_CMDRemovePlayer(int client,int args)
 }
 public void T_CallbackDeletePlayer(Handle owner,Handle hndl,const char[] error, StringMap QueryCode)
 {
+	int client;
+
+	QueryCode.GetValue("client", client);
+
+	if(ValidPlayer(client))
+	{
+		KickClient(client, "%t", "Kicked by admin");
+	}
+
 	PrintToServer("[War3Source:EVO] T_CallbackDeletePlayer()");
 	PrintToServer("[War3Source:EVO] %s",error);
+
+	if(QueryCode != null)
+	{
+		QueryCode.Close();
+	}
 }
 
 #if SHOPMENU3 == MODE_ENABLED

--- a/addons/sourcemod/scripting/War3Source_Addon_AdminConsole.sp
+++ b/addons/sourcemod/scripting/War3Source_Addon_AdminConsole.sp
@@ -103,7 +103,9 @@ public Action War3Source_CMDRemovePlayer(int client,int args)
 
 		SetConVarInt(war3_savexp_cvar,0);
 
-		for(int x=0;x<results;x++)
+		//for(int x=0;x<results;x++)
+		int x=0;
+		while(x<results)
 		{
 			new steamaccountid = GetSteamAccountID(client);
 
@@ -114,6 +116,7 @@ public Action War3Source_CMDRemovePlayer(int client,int args)
 
 			KickClient(client, "%t", "Kicked by admin");
 			results-=1;
+			x+=1;
 
 			// Remove player from database
 			hDB = W3GetVar(hDatabase);
@@ -125,7 +128,7 @@ public Action War3Source_CMDRemovePlayer(int client,int args)
 				new String:longquery[256];
 
 				//Prepare select query for main data
-				Format(longquery,sizeof(longquery),"DELETE FROM %s WHERE accountid='%d'",XP_GOLD_DATABASENAME,steamaccountid);
+				Format(longquery,sizeof(longquery),"DELETE FROM %s WHERE steamid='%d';",XP_GOLD_DATABASENAME,steamaccountid);
 
 				StringMap QueryCode = new StringMap();
 				QueryCode.SetValue("client",client);
@@ -137,7 +140,7 @@ public Action War3Source_CMDRemovePlayer(int client,int args)
 
 				// race data too
 
-				Format(longquery,sizeof(longquery),"DELETE FROM %s WHERE accountid='%d'",XP_GOLD_DATABASENAME_RACEDATA1,steamaccountid);
+				Format(longquery,sizeof(longquery),"DELETE FROM %s WHERE steamid='%d';",XP_GOLD_DATABASENAME_RACEDATA1,steamaccountid);
 
 				StringMap QueryCode2 = new StringMap();
 				QueryCode2.SetValue("client",client);

--- a/addons/sourcemod/scripting/War3Source_Addon_AdminConsole.sp
+++ b/addons/sourcemod/scripting/War3Source_Addon_AdminConsole.sp
@@ -113,6 +113,7 @@ public Action War3Source_CMDRemovePlayer(int client,int args)
 			War3_ChatMessage(client,"Your being deleted from database.");
 
 			KickClient(client, "%t", "Kicked by admin");
+			results-=1;
 
 			// Remove player from database
 			hDB = W3GetVar(hDatabase);

--- a/addons/sourcemod/scripting/War3Source_Addon_AdminConsole.sp
+++ b/addons/sourcemod/scripting/War3Source_Addon_AdminConsole.sp
@@ -107,6 +107,8 @@ public Action War3Source_CMDRemovePlayer(int client,int args)
 		int x=0;
 		while(x<results)
 		{
+			if(!ValidPlayer(x)) continue;
+
 			new steamaccountid = GetSteamAccountID(client);
 
 			char name[64];

--- a/addons/sourcemod/scripting/War3Source_Addon_HelpMenuConfiguration.sp
+++ b/addons/sourcemod/scripting/War3Source_Addon_HelpMenuConfiguration.sp
@@ -53,6 +53,15 @@ public APLRes:AskPluginLoad2Custom(Handle:myself,bool:late,String:error[],err_ma
 	return APLRes_Success;
 }
 
+public OnAllPluginsLoaded()
+{
+	W3Hook(W3Hook_OnWar3Event, OnWar3Event);
+}
+public OnPluginEnd()
+{
+	W3UnhookAll(W3Hook_OnWar3Event);
+}
+
 public OnPluginStart()
 {
 	RegAdminCmd("printhelpmenu", printhelpmenu, ADMFLAG_ROOT);
@@ -119,18 +128,28 @@ public Action printhelpmenu(int client, int args)
 public int LoadConfig()
 {
 	if (DebugOn() == true) { PrintToServer("1-LOADING HELP CONFIG..."); }
-// auto grabs for game mode:
-#if (GGAMETYPE == GGAME_CSS)
-	new Handle: kv = CreateKeyValues("CSS");
-#elseif (GGAMETYPE == GGAME_CSGO)
-	new Handle: kv = CreateKeyValues("CSGO");
-#elseif (GGAMETYPE == GGAME_FOF)
-	new Handle: kv = CreateKeyValues("FOF");
-#elseif (GGAMETYPE == GGAME_TF2)
-	new Handle: kv = CreateKeyValues("TF2");
-#endif
+
+	new Handle: kv = CreateKeyValues("war3sourcehelpmenu");
 
 	FileToKeyValues(kv, "addons/sourcemod/configs/war3source_help_menu.cfg");
+	KvRewind(kv);
+
+// auto grabs for game mode:
+#if (GGAMETYPE == GGAME_CSS)
+	if(!KvJumpToKey(kv,"CSS"))
+		SetFailState("error, key value for levels configuration not found");
+#elseif (GGAMETYPE == GGAME_CSGO)
+	if(!KvJumpToKey(kv,"CSGO"))
+		SetFailState("error, key value for levels configuration not found");
+#elseif (GGAMETYPE == GGAME_FOF)
+	if(!KvJumpToKey(kv,"FOF"))
+		SetFailState("error, key value for levels configuration not found");
+#elseif (GGAMETYPE == GGAME_TF2)
+	if(!KvJumpToKey(kv,"TF2"))
+		SetFailState("error, key value for levels configuration not found");
+#else
+	ThrowNativeError(80070666, "ERROR: UNSUPPORTED GAME MODE");
+#endif
 
 	if (!KvGotoFirstSubKey(kv))
 	{
@@ -191,7 +210,7 @@ public int LoadConfig()
 
 public void OnWar3Event(W3EVENT event,int client)
 {
-	if(!War3_HelpMenu_Enabled()) return;
+	if(War3_HelpMenu_Enabled()==false) return;
 
 	if(event==DoShowWar3Menu)
 	{

--- a/addons/sourcemod/scripting/compile_for_github_action.sh
+++ b/addons/sourcemod/scripting/compile_for_github_action.sh
@@ -28,12 +28,12 @@ then
 	do
 		fullpathsourcefile="`echo $fullpath/$i`";
 		smxfile="`echo $i | sed -e 's/\.sp$/\.smx/'`";
-		if [[ $smxfile =~ "War3Source_Addon_HelpMenuConfiguration" ]]; then
-			#outputfile="`echo $fullpath/compiled/$smxfile`"
-			outputfile="`echo $pluginDisabledPath/$smxfile`"
-			echo -n "Single File Compiling $i...";
-			./spcomp_1.9.0.6261 -t4 -v2 $fullpathsourcefile -o$outputfile
-		elif [[ $smxfile =~ "War3Source_Addon_Sound_Change" ]]; then
+		#if [[ $smxfile =~ "War3Source_Addon_HelpMenuConfiguration" ]]; then
+		#	#outputfile="`echo $fullpath/compiled/$smxfile`"
+		#	outputfile="`echo $pluginDisabledPath/$smxfile`"
+		#	echo -n "Single File Compiling $i...";
+		#	./spcomp_1.9.0.6261 -t4 -v2 $fullpathsourcefile -o$outputfile
+		if [[ $smxfile =~ "War3Source_Addon_Sound_Change" ]]; then
 			#outputfile="`echo $fullpath/compiled/$smxfile`"
 			outputfile="`echo $pluginDisabledPath/$smxfile`"
 			echo -n "Single File Compiling $i...";
@@ -50,11 +50,11 @@ for sourcefile in *.sp
 do
 	fullpathsourcefile="`echo $fullpath/$sourcefile`";
 	smxfile="`echo $sourcefile | sed -e 's/\.sp$/\.smx/'`";
-	if [[ $smxfile =~ "War3Source_Addon_HelpMenuConfiguration" ]]; then
-		outputfile="`echo $pluginDisabledPath/$smxfile`"
-		echo -n "All Files Compiling $sourcefile...";
-		./spcomp_1.9.0.6261 -t4 -v2 $fullpathsourcefile -o$outputfile;
-	elif [[ $smxfile =~ "War3Source_Addon_Sound_Change" ]]; then
+	#if [[ $smxfile =~ "War3Source_Addon_HelpMenuConfiguration" ]]; then
+	#	outputfile="`echo $pluginDisabledPath/$smxfile`"
+	#	echo -n "All Files Compiling $sourcefile...";
+	#	./spcomp_1.9.0.6261 -t4 -v2 $fullpathsourcefile -o$outputfile;
+	if [[ $smxfile =~ "War3Source_Addon_Sound_Change" ]]; then
 		outputfile="`echo $pluginDisabledPath/$smxfile`"
 		echo -n "All Files Compiling $sourcefile...";
 		./spcomp_1.9.0.6261 -t4 -v2 $fullpathsourcefile -o$outputfile;

--- a/addons/sourcemod/scripting/include/GAME_SWITCHER/currentgame.inc
+++ b/addons/sourcemod/scripting/include/GAME_SWITCHER/currentgame.inc
@@ -51,26 +51,8 @@
 
 //CSGO
 //Uncomment below for CSGO:
-#define GGAMETYPE GGAME_CSGO
-#define GGAMETYPE2 GGAME_CSGO_2
-#define GGAMETYPE_KDR KDR_OFF
-#define GGAMETYPE_JAILBREAK JAILBREAK_OFF
-#define GGAMEMODE MODE_WAR3SOURCE
-#define CYBORG_SKIN MODE_DISABLED
-#define SHOPMENU3 MODE_DISABLED
-// This was programmally added in to try to have more control
-// over spammy War3Source because CSGO can't handle so much
-// client spam.  I didn't fully complete it.  If someone else
-// wishes to complete this, you can turn it on in currentgame.inc
-// This does not help a normal server owner, but may extend itself for a programmer.
-#define MESSAGE_CONTROL_MODE MODE_DISABLED
-//Stop of uncomment for CSGO
-
-
-////CSS
-//Uncomment below for CSS:
-//#define GGAMETYPE GGAME_CSS
-//#define GGAMETYPE2 GGAME_CSS_2
+//#define GGAMETYPE GGAME_CSGO
+//#define GGAMETYPE2 GGAME_CSGO_2
 //#define GGAMETYPE_KDR KDR_ON
 //#define GGAMETYPE_JAILBREAK JAILBREAK_OFF
 //#define GGAMEMODE MODE_WAR3SOURCE
@@ -82,6 +64,24 @@
 // wishes to complete this, you can turn it on in currentgame.inc
 // This does not help a normal server owner, but may extend itself for a programmer.
 //#define MESSAGE_CONTROL_MODE MODE_DISABLED
+//Stop of uncomment for CSGO
+
+
+////CSS
+//Uncomment below for CSS:
+#define GGAMETYPE GGAME_CSS
+#define GGAMETYPE2 GGAME_CSS_2
+#define GGAMETYPE_KDR KDR_OFF
+#define GGAMETYPE_JAILBREAK JAILBREAK_OFF
+#define GGAMEMODE MODE_WAR3SOURCE
+#define CYBORG_SKIN MODE_DISABLED
+#define SHOPMENU3 MODE_DISABLED
+// This was programmally added in to try to have more control
+// over spammy War3Source because CSGO can't handle so much
+// client spam.  I didn't fully complete it.  If someone else
+// wishes to complete this, you can turn it on in currentgame.inc
+// This does not help a normal server owner, but may extend itself for a programmer.
+#define MESSAGE_CONTROL_MODE MODE_DISABLED
 //Stop of uncomment for CSS
 
 
@@ -89,7 +89,7 @@
 //Uncomment below for FoF:
 //#define GGAMETYPE GGAME_FOF
 //#define GGAMETYPE2 GGAME_FOF_2
-//#define GGAMETYPE_KDR KDR_OFF
+//#define GGAMETYPE_KDR KDR_ON
 //#define GGAMETYPE_JAILBREAK JAILBREAK_OFF
 //#define GGAMEMODE MODE_WAR3SOURCE
 //#define CYBORG_SKIN MODE_DISABLED

--- a/addons/sourcemod/translations/w3s._common.phrases.txt
+++ b/addons/sourcemod/translations/w3s._common.phrases.txt
@@ -6,9 +6,9 @@
 	}
 
 	//War3Source_Engine_AdminConsole.sp
-	"[War3Source:EVO] The syntax of the command is: war3_removeplayer <player>""
+	"[War3Source:EVO] The syntax of the command is: war3_removeplayer <player>"
 	{
-		"en"		"[War3Source:EVO] The syntax of the command is: war3_removeplayer <player>""
+		"en"		"[War3Source:EVO] The syntax of the command is: war3_removeplayer <player>"
 	}
 	"[War3Source:EVO] The syntax of the command is: war3_setxp <player> <xp>"
 	{

--- a/addons/sourcemod/translations/w3s._common.phrases.txt
+++ b/addons/sourcemod/translations/w3s._common.phrases.txt
@@ -6,6 +6,10 @@
 	}
 
 	//War3Source_Engine_AdminConsole.sp
+	"[War3Source:EVO] The syntax of the command is: war3_removeplayer <player>""
+	{
+		"en"		"[War3Source:EVO] The syntax of the command is: war3_removeplayer <player>""
+	}
 	"[War3Source:EVO] The syntax of the command is: war3_setxp <player> <xp>"
 	{
 		"en"		"[War3Source:EVO] The syntax of the command is: war3_setxp <player> <xp>"

--- a/updatecss.sh
+++ b/updatecss.sh
@@ -214,6 +214,9 @@ if $update_war3; then
     # Copy Translations
     cp -vrf --remove-destination "${CPATH}/War3Source-EVO/addons/sourcemod/translations" "${SourceMetaModWar3InstallPath}/addons/sourcemod"
 
+    # Copy Extensions
+    cp -vrf --remove-destination "${CPATH}/War3Source-EVO/addons/sourcemod/extensions" "${SourceMetaModWar3InstallPath}/addons/sourcemod" | tee -a update_log.txt
+
     # Store difference between CFG and CONFIG files and output them at the end
     diff -ar "${CPATH}/War3Source-EVO/cfg" "${SourceMetaModWar3InstallPath}/cfg" > CFGdifferences.txt
     diff -ar "${CPATH}/War3Source-EVO/addons/sourcemod/configs" "${SourceMetaModWar3InstallPath}/addons/sourcemod/configs" > CONFIGdifferences.txt


### PR DESCRIPTION
**War3Source_Addon_HelpMenuConfiguration.sp**
moved War3Source_Addon_HelpMenuConfiguration out of disabled plugins
requires war3source_help_menu.cfg

**War3Source_Addon_AdminConsole.sp**
Adding the ability to remove players from database
Only ROOT admin will be allowed to do this command.
You must have war3_removeplayer_enabled 1 to be able to do the command.

This will kick a player before it deletes them.

war3_removeplayer_enabled 1  (default is 0)
war3_removeplayer <player>  (Be careful, it will look for all players matching name)

This was created for development purposes and to make it easier to do this without having to manually access it yourself.

